### PR TITLE
Fix insertable items

### DIFF
--- a/cp/appian-component-plugin.xml
+++ b/cp/appian-component-plugin.xml
@@ -4,7 +4,7 @@
     <description>A simple rich text editor</description>
     <support supported="false" email="richtext-componentpluginsupport@appian.com" />
     <vendor name="Appian" url="https://www.appian.com"/>
-    <version>1.12.0</version>
+    <version>1.12.1</version>
   </plugin-info>
   <component rule-name="richTextField" version="1.0.0">
     <sdk-version>2.0.0</sdk-version>

--- a/cp/richTextFieldWithTables/v1/index.js
+++ b/cp/richTextFieldWithTables/v1/index.js
@@ -77,7 +77,12 @@ const ALLOWED_TAGS = [
   "a",
 ];
 const ALLOWED_ATTRIBUTES = ["style", "color", "href", "target"];
-const ALLOWED_STYLE_ATTRIBUTES = ["font-size", "background-color", "text-align", "margin-left"];
+const ALLOWED_STYLE_ATTRIBUTES = [
+  "font-size",
+  "background-color",
+  "text-align",
+  "margin-left",
+];
 const MAX_SIZE_DEFAULT = 10000;
 const DISPLAY_PARAMS = [
   "height",
@@ -143,14 +148,18 @@ function buildEditor() {
   if (!isReadOnly()) {
     // 72px is arbitrarily determined based on the height of the toolbar
     var height =
-      window.allParameters.height === "auto" ? "auto" : parseInt(window.allParameters.height) - 72;
+      window.allParameters.height === "auto"
+        ? "auto"
+        : parseInt(window.allParameters.height) - 72;
 
     // Code for the insertable items button
     var insertableItemsFiltered = [];
     if (window.allParameters.insertableItems) {
-      insertableItemsFiltered = window.allParameters.insertableItems.filter(function (i) {
-        return i.label && i.value;
-      });
+      insertableItemsFiltered = window.allParameters.insertableItems.filter(
+        function (i) {
+          return i.label && i.value;
+        }
+      );
     }
     var insertableItemsButton = function (context) {
       var ui = $.summernote.ui;
@@ -170,7 +179,7 @@ function buildEditor() {
             : [],
           callback: function (items) {
             $(items)
-              .find("li a")
+              .find(".dropdown-item")
               .on("click", function (e) {
                 var selectedItem = $(this).html();
                 insertableItemsFiltered.map(function (i) {
@@ -267,7 +276,9 @@ function returnDisplayParams() {
   var displayParams = {};
   for (var i = 0; i < DISPLAY_PARAMS.length; i++) {
     var param = DISPLAY_PARAMS[i];
-    displayParams[param] = !window.allParameters ? "" : window.allParameters[param];
+    displayParams[param] = !window.allParameters
+      ? ""
+      : window.allParameters[param];
   }
   return displayParams;
 }
@@ -368,7 +379,9 @@ function setDynamicCss() {
     // STANDARD
     tableBorderWidth = "1px";
   }
-  cssStyles.push("table, td, th, tr {border-width: " + tableBorderWidth + " !important}");
+  cssStyles.push(
+    "table, td, th, tr {border-width: " + tableBorderWidth + " !important}"
+  );
 
   // set styles
   styleEl.innerHTML = cssStyles.join("\n");
@@ -414,7 +427,10 @@ function validate(forceUpdate) {
   if (!isReadOnly() && getEditorContents().length > maxSize) {
     newValidations.push("Content exceeds maximum allowed size");
   }
-  if (forceUpdate || newValidations.toString() !== window.currentValidations.toString()) {
+  if (
+    forceUpdate ||
+    newValidations.toString() !== window.currentValidations.toString()
+  ) {
     Appian.Component.setValidations(newValidations);
     // Note, uncomment the following line to debug when validations are saved out
     // console.log("validations out: " + newValidations + " " + Date.now());
@@ -498,9 +514,12 @@ function cleanHtml(html, isPartialHtml) {
           if ($1 === "style") {
             // Step 4: Remove all unnecessary HTML style attributes
             // Test this Regex here: https://regexr.com/64gqb
-            return $0.replace(/([\w-]+): ?(?:[^;]|&quot;)*?;? ?(?=[^;]*:|")/g, function ($0, $1) {
-              return ALLOWED_STYLE_ATTRIBUTES.indexOf($1) > -1 ? $0 : "";
-            });
+            return $0.replace(
+              /([\w-]+): ?(?:[^;]|&quot;)*?;? ?(?=[^;]*:|")/g,
+              function ($0, $1) {
+                return ALLOWED_STYLE_ATTRIBUTES.indexOf($1) > -1 ? $0 : "";
+              }
+            );
           } else {
             return $0;
           }
@@ -520,7 +539,9 @@ function cleanHtml(html, isPartialHtml) {
   // Test this Regex here: https://regexr.com/64iom
   out = out.replace(/<a.*?href="(.*?)">(.*?)<\/a>/g, function ($0, $1, $2) {
     // Test this Regex here: https://regexr.com/6blub
-    return $1.match(/^(?:[A-Za-z0-9+\-.]+:)?(?:https:\/\/?|mailto:).*$/g) ? $0 : $2;
+    return $1.match(/^(?:[A-Za-z0-9+\-.]+:)?(?:https:\/\/?|mailto:).*$/g)
+      ? $0
+      : $2;
   });
 
   // Step 6: Remove any HTML comments


### PR DESCRIPTION
The `insertableItems` parameter (a dropdown of tags to insert) stopped working.

The dom was previously `<li><a>` but switched to `<div><a>` when [we upgraded bootstrap](https://github.com/appian/rich-text-editor-plugin/commit/d82d2eccda6516ff9d50fbba52cc1910e4b290d3).

Now selecting by class (`.dropdown-item`) which should be much more robust.