### PR TITLE
fix refresh of content while typing

### DIFF
--- a/cp/appian-component-plugin.xml
+++ b/cp/appian-component-plugin.xml
@@ -4,7 +4,7 @@
     <description>A simple rich text editor</description>
     <support supported="false" email="richtext-componentpluginsupport@appian.com" />
     <vendor name="Appian" url="https://www.appian.com"/>
-    <version>1.12.1</version>
+    <version>1.12.2</version>
   </plugin-info>
   <component rule-name="richTextField" version="1.0.0">
     <sdk-version>2.0.0</sdk-version>

--- a/cp/richTextFieldWithTables/v1/index.js
+++ b/cp/richTextFieldWithTables/v1/index.js
@@ -38,7 +38,6 @@ summernote.on(
   "summernote.change", 
     debounceOnChange(function () {
       // Only run if the editor still has focus
-      //console.log("saving data");
       if (window.hasFocus) {
         setAppianValue();
       }
@@ -315,9 +314,6 @@ function setAppianValue() {
       window.lastSaveTime = Date.now();
       Appian.Component.saveValue("richText", newSaveOutValue);
       window.lastSaveOutValue = newSaveOutValue;
-      // Note, uncomment the following line to debug when richText is saved out
-      // console.log("save out: " + newSaveOutValue + " " + Date.now());
-      // console.log("save out " + Date.now());
     }
   }
 }
@@ -332,8 +328,6 @@ function setEditorContents() {
     summernote.summernote("code", cleanHtml(window.allParameters.richText));
     summernote.summernote("destroy");
   } else {
-    //console.log("before - last save " + window.lastSaveTime);
-    //console.log("before - last chng " + window.lastOnchangeTime);
     // Otherwise, only update the contents if they've actually changed to avoid triggering the onChange event
     if (
       window.allParameters.richText !== window.lastSaveOutValue &&
@@ -341,26 +335,11 @@ function setEditorContents() {
     ) {
       // Only update the contents if the last save occurred after the last onChange
       if (window.lastSaveTime >= (window.lastOnchangeTime + 600)) {
-        //console.log("content refreshed from Appian");
-        //console.log("last save - refreshed " + window.lastSaveTime);
-        //console.log("last chng - refreshed " + window.lastOnchangeTime);
         summernote.summernote("code", cleanHtml(window.allParameters.richText));
-        
-        
       } 
-      /*
-      else {
-        console.log("skip content refresh because last save time is less than last onchange time");
-        console.log("last save " + window.lastSaveTime);
-        console.log("last chng " + window.lastOnchangeTime);
-      }
-      */
     } else {
       // Reset the lastSaveTime
       window.lastSaveTime = window.lastOnchangeTime + 600;
-      //console.log("skip content refresh because user modified content since last save");
-      //console.log("last save " + window.lastSaveTime);
-      //console.log("last chng " + window.lastOnchangeTime);
     }
   }
 }
@@ -460,8 +439,6 @@ function validate(forceUpdate) {
     newValidations.toString() !== window.currentValidations.toString()
   ) {
     Appian.Component.setValidations(newValidations);
-    // Note, uncomment the following line to debug when validations are saved out
-    // console.log("validations out: " + newValidations + " " + Date.now());
   }
   window.currentValidations = newValidations;
   return window.currentValidations.length === 0;
@@ -631,7 +608,6 @@ function debounceOnChange(func, delay) {
   var inDebounce;
   return function () {
     window.lastOnchangeTime = Date.now();
-    //console.log("onchange");
     const context = this;
     const args = arguments;
     clearTimeout(inDebounce);

--- a/cp/richTextFieldWithTables/v1/index.js
+++ b/cp/richTextFieldWithTables/v1/index.js
@@ -38,7 +38,7 @@ summernote.on(
   "summernote.change", 
     debounceOnChange(function () {
       // Only run if the editor still has focus
-      // console.log("saving data");
+      //console.log("saving data");
       if (window.hasFocus) {
         setAppianValue();
       }
@@ -341,17 +341,20 @@ function setEditorContents() {
     ) {
       // Only update the contents if the last save occurred after the last onChange
       if (window.lastSaveTime >= (window.lastOnchangeTime + 600)) {
+        //console.log("content refreshed from Appian");
         //console.log("last save - refreshed " + window.lastSaveTime);
         //console.log("last chng - refreshed " + window.lastOnchangeTime);
         summernote.summernote("code", cleanHtml(window.allParameters.richText));
-        //console.log("content refreshed from Appian");
+        
         
       } 
-      //else {
-        //console.log("skip content refresh because last save time is less than last onchange time");
-        //console.log("last save " + window.lastSaveTime);
-        //console.log("last chng " + window.lastOnchangeTime);
-      //}
+      /*
+      else {
+        console.log("skip content refresh because last save time is less than last onchange time");
+        console.log("last save " + window.lastSaveTime);
+        console.log("last chng " + window.lastOnchangeTime);
+      }
+      */
     } else {
       // Reset the lastSaveTime
       window.lastSaveTime = window.lastOnchangeTime + 600;

--- a/cp/richTextFieldWithTables/v1/index.js
+++ b/cp/richTextFieldWithTables/v1/index.js
@@ -35,13 +35,15 @@ summernote.on("summernote.focus", function () {
   window.hasFocus = true;
 });
 summernote.on(
-  "summernote.change",
-  debounce(function () {
-    // Only run if the editor still has focus
-    if (window.hasFocus) {
-      setAppianValue();
-    }
-  }, 500)
+  "summernote.change", 
+    debounceOnChange(function () {
+      // Only run if the editor still has focus
+      // console.log("saving data");
+      if (window.hasFocus) {
+        setAppianValue();
+      }
+    }, 500)
+
 );
 summernote.on("summernote.paste", function (we, e) {
   e.preventDefault();
@@ -99,6 +101,8 @@ window.hasFocus = false;
 window.currentDisplayParameters = returnDisplayParams();
 window.currentValidations = [];
 window.lastSaveOutValue = "";
+window.lastSaveTime = Date.now()+1000;
+window.lastOnchangeTime = Date.now();
 
 /**
  * Initializes summernote editor and handles all new values passed from Appian SAIL to the component
@@ -308,6 +312,7 @@ function setAppianValue() {
     var newSaveOutValue = cleanHtml(getEditorContents());
     // Always save-out unless the new value we would be saving out matches the last value we saved out
     if (window.lastSaveOutValue !== newSaveOutValue) {
+      window.lastSaveTime = Date.now();
       Appian.Component.saveValue("richText", newSaveOutValue);
       window.lastSaveOutValue = newSaveOutValue;
       // Note, uncomment the following line to debug when richText is saved out
@@ -327,12 +332,32 @@ function setEditorContents() {
     summernote.summernote("code", cleanHtml(window.allParameters.richText));
     summernote.summernote("destroy");
   } else {
+    //console.log("before - last save " + window.lastSaveTime);
+    //console.log("before - last chng " + window.lastOnchangeTime);
     // Otherwise, only update the contents if they've actually changed to avoid triggering the onChange event
     if (
       window.allParameters.richText !== window.lastSaveOutValue &&
       window.allParameters.richText !== getEditorContents()
     ) {
-      summernote.summernote("code", cleanHtml(window.allParameters.richText));
+      // Only update the contents if the last save occurred after the last onChange
+      if (window.lastSaveTime >= (window.lastOnchangeTime + 600)) {
+        //console.log("last save - refreshed " + window.lastSaveTime);
+        //console.log("last chng - refreshed " + window.lastOnchangeTime);
+        summernote.summernote("code", cleanHtml(window.allParameters.richText));
+        //console.log("content refreshed from Appian");
+        
+      } 
+      //else {
+        //console.log("skip content refresh because last save time is less than last onchange time");
+        //console.log("last save " + window.lastSaveTime);
+        //console.log("last chng " + window.lastOnchangeTime);
+      //}
+    } else {
+      // Reset the lastSaveTime
+      window.lastSaveTime = window.lastOnchangeTime + 600;
+      //console.log("skip content refresh because user modified content since last save");
+      //console.log("last save " + window.lastSaveTime);
+      //console.log("last chng " + window.lastOnchangeTime);
     }
   }
 }
@@ -590,6 +615,20 @@ function isInternetExplorer() {
 function debounce(func, delay) {
   var inDebounce;
   return function () {
+    const context = this;
+    const args = arguments;
+    clearTimeout(inDebounce);
+    inDebounce = setTimeout(function () {
+      func.apply(context, args);
+    }, delay);
+  };
+}
+
+function debounceOnChange(func, delay) {
+  var inDebounce;
+  return function () {
+    window.lastOnchangeTime = Date.now();
+    //console.log("onchange");
     const context = this;
     const args = arguments;
     clearTimeout(inDebounce);


### PR DESCRIPTION
In order to prevent the weird refresh behavior where the cursor would move to the beginning of the text while a user is typing, I added 2 new variables:
- time last save
- time last updated

Before refreshing the content of the field, I compare the time last save with the time last updated to prevent refresh from Appian to override the data while the user is typing.