### PR TITLE
fix refresh of content while typing 2

### DIFF
--- a/cp/appian-component-plugin.xml
+++ b/cp/appian-component-plugin.xml
@@ -4,7 +4,7 @@
     <description>A simple rich text editor</description>
     <support supported="false" email="richtext-componentpluginsupport@appian.com" />
     <vendor name="Appian" url="https://www.appian.com"/>
-    <version>1.12.2</version>
+    <version>1.12.3</version>
   </plugin-info>
   <component rule-name="richTextField" version="1.0.0">
     <sdk-version>2.0.0</sdk-version>


### PR DESCRIPTION
Fixing an issue introduced in #12 and using the same paradigm as [Quill uses](https://github.com/appian/rich-text-editor-plugin/blob/master/cp/richTextField/v1/index.js#L303-L305) which just checks if the editor has focus.