### PR TITLE
Bug Fix: Enable images to be pre-loaded into RTE during initialization

### DIFF
--- a/cp/richTextFieldWithTables/v1/custom.css
+++ b/cp/richTextFieldWithTables/v1/custom.css
@@ -91,15 +91,15 @@ h6 {
   font-size: 14px !important;
 }
 .dropdown-item{
-    padding: 3px 20px !important;
+  padding: 3px 20px !important;
 }
 
 .dropdown-item > p{
- margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 .dropdown-menu{
-    font-size:14px !important;
-    padding: 5px 0 !important;
+  font-size:14px !important;
+  padding: 5px 0 !important;
 }
 .note-btn-group .note-btn {
   color:#000;

--- a/cp/richTextFieldWithTables/v1/index.js
+++ b/cp/richTextFieldWithTables/v1/index.js
@@ -706,20 +706,10 @@ function cleanHtml(html, isPartialHtml) {
 
   // END TEMPORARY REFACTOR FOR IE -- ABOVE WILL BE DELETED ONCE IE IS DEPRECATED
 
-  // Step 5: Strip non-external links
-  // Any hyperlink that isn't to an external URL or mailto URL will not work as expected anyways, so this will strip those hyperlinks
-  // Test this Regex here: https://regexr.com/64iom
-  out = out.replace(/<a.*?href="(.*?)">(.*?)<\/a>/g, function ($0, $1, $2) {
-    // Test this Regex here: https://regexr.com/6blub
-    return $1.match(/^(?:[A-Za-z0-9+\-.]+:)?(?:https:\/\/?|mailto:).*$/g)
-      ? $0
-      : $2;
-  });
-
-  // Step 6: Remove any HTML comments
+  // Step 5: Remove any HTML comments
   out = out.replace(/<!--.*?-->/g, "");
 
-  // Step 7: Trim extra spaces
+  // Step 6: Trim extra spaces
   out = out.trim().replace(/ +/g, " ");
 
   return out;

--- a/cp/richTextFieldWithTables/v1/index.js
+++ b/cp/richTextFieldWithTables/v1/index.js
@@ -125,6 +125,10 @@ Appian.Component.onNewValue(function (allParameters) {
   window.allParameters = allParameters;
   window.connectedSystem = allParameters.imageStorageConnectedSystem;
   window.allowImages = allParameters.allowImages;
+  /* If images are allowed, then update ALLOWED_TAGS to include <img> tags */
+  if (window.allowImages) {
+    ALLOWED_TAGS.push("img");
+  }
   // First immediately set the contents before even building to avoid triggering onChange events
   setEditorContents();
 
@@ -240,12 +244,9 @@ function buildEditor() {
     if (window.allParameters.insertableItemsLabel.length > 0) {
       toolbar.splice(7, 0, ["insertableItems", ["insertableItems"]]);
     }
-    /* Check to see if images are allowed. If so, then add images to summernote toolbar and 
-     * push <img> html tag to ALLOWED_TAGS list
-     */
+    /* Check to see if images are allowed. If so, then add images to summernote toolbar */
     if (window.allowImages) {
       toolbar.find(group => group[0] === "group6")[1].push("picture");
-      ALLOWED_TAGS.push("img");
     }
 
     summernote.summernote({


### PR DESCRIPTION
Issue: If preloaded HTML contains images prior to RTE initialization, they were being filtered out and not passed into the RTE.

Resolution: Validate if images are allowed prior to setEditorContents() where pre-loaded HTML was being cleaned prior to building the summernote RTE.