### PR TITLE
Address subscript/superscript toolbar defect and fix additional styling issues

### DIFF
--- a/cp/richTextFieldWithTables/v1/custom.css
+++ b/cp/richTextFieldWithTables/v1/custom.css
@@ -93,13 +93,13 @@ p {
 }
 /* Move subscript upward (toward top of parent text) */
 .note-editable sub {
-  position: relative;
-  top: -0.2em;
+  position: relative !important;
+  top: -0.2em !important;
 }
 /* Move superscript downward (closer to baseline) */
 .note-editable sup {
-  position: relative;
-  top: 0.2em;
+  position: relative !important;
+  top: 0.1em !important;
 }
 .dropdown-item > h3 {
   font-size: 18px !important;

--- a/cp/richTextFieldWithTables/v1/custom.css
+++ b/cp/richTextFieldWithTables/v1/custom.css
@@ -9,6 +9,7 @@ span {
 }
 span,
 p,
+ol,
 .note-editable {
   font-size: 14px;
 }
@@ -90,10 +91,15 @@ h6 {
 p {
   margin-bottom: 0px !important;
 }
-/* Use same vertical-align for subscripts and superscripts as read-only mode */
-sub,
-sup {
-  vertical-align: baseline !important;
+/* Move subscript upward (toward top of parent text) */
+.note-editable sub {
+  position: relative;
+  top: -0.2em;
+}
+/* Move superscript downward (closer to baseline) */
+.note-editable sup {
+  position: relative;
+  top: 0.2em;
 }
 .dropdown-item > h3 {
   font-size: 18px !important;


### PR DESCRIPTION
1. Include ol as a part of the default font-size: 14px.
    **Issue**: Text within lists default to font-size 16 in readOnly mode.

2. Needed to remove vertical-align and address the subscripts and superscripts styling accordingly.
    **Issue**: For some reason, summernote does not like us overriding the vertical-align as it messes with the active state of subscripts and superscripts. For example, if you click the subscript or superscript button, the button will show it's active but as soon as you start typing, it appears to be unselected despite staying in the sub/superscript node.
   **Fix**: Modify the stylings for subscripts and superscripts accordingly and match them between editable and readOnly mode.