### PR TITLE
Enhance Copy and Paste Capabilties: Text, Image, and Tables

### DIFF
--- a/cp/richTextFieldWithTables/v1/index.js
+++ b/cp/richTextFieldWithTables/v1/index.js
@@ -763,6 +763,11 @@ function cleanHtml(html, isPartialHtml) {
   // Step 8: Trim extra spaces
   out = out.trim().replace(/ +/g, " ");
 
+  // Step 9: Repair orphan table rows (Word paste)
+  if (/<tr[\s>]/i.test(out) && !/<table[\s>]/i.test(out)) {
+    out = "<table><tbody>" + out + "</tbody></table>";
+  }
+  
   return out;
 }
 

--- a/cp/richTextFieldWithTables/v1/index.js
+++ b/cp/richTextFieldWithTables/v1/index.js
@@ -742,7 +742,10 @@ function cleanHtml(html, isPartialHtml) {
 
   // END TEMPORARY REFACTOR FOR IE -- ABOVE WILL BE DELETED ONCE IE IS DEPRECATED
 
-  // Step 5: Strip non-external links
+  // Step 5: Replace empty spans (introduce by paste event) with a space.
+  out = out.replace(/<span[^>]*>\s*<\/span>/gi, " ");
+  
+  // Step 6: Strip non-external links
   // Any hyperlink that isn't to an external URL or file URL or mailto URL will not work as expected anyways, so this will strip those hyperlinks
   // Test this Regex here: https://regexr.com/64iom
   out = out.replace(/<a.*?href="(.*?)">(.*?)<\/a>/g, function ($0, $1, $2) {
@@ -754,10 +757,10 @@ function cleanHtml(html, isPartialHtml) {
       : $2;
   });
 
-  // Step 6: Remove any HTML comments
+  // Step 7: Remove any HTML comments
   out = out.replace(/<!--.*?-->/g, "");
 
-  // Step 7: Trim extra spaces
+  // Step 8: Trim extra spaces
   out = out.trim().replace(/ +/g, " ");
 
   return out;

--- a/cp/richTextFieldWithTables/v1/index.js
+++ b/cp/richTextFieldWithTables/v1/index.js
@@ -49,19 +49,58 @@ summernote.on(
 );
 summernote.on("summernote.paste", function (we, e) {
   e.preventDefault();
-  /* Determine if clipboard contains an <img> tag.
-   * If so - skip pasting images as it's handled by onImageUpload.
-   */
   let clipboardHtml = readClipboard(e);
-  if (clipboardHtml.indexOf("<img") !== -1) {
-    return;
+
+  // If clipboard contains an external images (Online Images), let the onImageUpload Callback handle it to avoid duplicate pasting of images
+  const EXTERNAL_WEB_IMAGE_REGEX = /<img[^>]+src=["'](https?:\/\/[^"']+\.(?:jpg|jpeg|png|gif)(?:\?[^"']*)?)["']/i;
+  if (EXTERNAL_WEB_IMAGE_REGEX.test(clipboardHtml)) {
+	return;
   }
-  handleImagePasteFromFile(e);
-  var cleanedHtml = cleanHtml(clipboardHtml, true);
-  cleanedHtml = stripSummernoteDefaults(cleanedHtml);
-  /* Wrap HTML around <span> tags to ensure it is pasted as a single node */
-  cleanedHtml = "<span>" + cleanedHtml + "</span>";
-  summernote.summernote("pasteHTML", cleanedHtml);
+
+  // Clear any newlines present in ordered lists from Word before the DOMParser splits the HTML into nodes and replaces them with <br>
+  if(clipboardHtml.indexOf("mso-list")!==-1){ 
+    const WORD_ORDERED_LIST_REGEX = /<!\[if !supportLists\]>([\s\S]*?)<!\[endif\]>/gi
+    clipboardHtml = clipboardHtml.replace(WORD_ORDERED_LIST_REGEX,function(match, content){
+	  return content.replace(/\r?\n/g,"");
+	});
+  }
+  
+  // Parse clipboard HTML into a DOM and iterate over top-level nodes
+  var parser = new DOMParser();
+  var doc = parser.parseFromString(clipboardHtml, "text/html");
+  var nodes = doc.body.childNodes;
+  var cleanedHtml = "";
+
+  nodes.forEach(function(node) {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+	  var nodeHtml = node.outerHTML;
+	  var cleaned = cleanHtml(nodeHtml, true);
+	  cleaned = stripSummernoteDefaults(cleaned);
+	  cleanedHtml += cleaned;
+	} else if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
+	  cleanedHtml += node.textContent;
+	}
+  });
+  
+  // Insert cleaned HTML at cursor position using insertNode to avoid splitting existing content
+  var insertParser = new DOMParser();
+  var insertDoc = insertParser.parseFromString(cleanedHtml,"text/html");
+  var insertNodes = Array.from(insertDoc.body.childNodes); 
+  
+  insertNodes.forEach(function(node){ 
+    $("#summernote").summernote("insertNode", node);
+  });
+  
+  // If the last inserted node was a table, add an empty paragraph after it so the cursor is below the table
+  var lastNode = insertNodes[insertNodes.length-1];
+  if(lastNode && lastNode.nodeName.toLowerCase()==="table"){
+    var emptyPara =document.createElement("p"); 
+    emptyPara.innerHTML="<br>"; 
+    summernote.summernote("editor.insertNode", emptyPara);
+  }
+  
+  // handleImagePasteFromFile(e);
+  // summernote.summernote("pasteHTML", cleanedHtml);
 });
 
 // After investigating, we determined that only these tags & attributes are necessary/supported in order to render all supported styles of the editor
@@ -660,9 +699,14 @@ function cleanHtml(html, isPartialHtml) {
     out = out
       // Word sometimes uses \r\n to represent a space
       .replace(/\r\n/g, " ")
-      .replace(/\n/g, "<br>")
-      // Remove whitespace between tags
+	  // Remove newlines from within tag attributes, converting them to spaces so they don't become <br> tags
+	  .replace(/<[^>]+>/g, function(tag) {
+		  return tag.replace(/\n/g, " ");
+	  })
+	  // Remove whitespace between tags
       .replace(/>\s+</g, "><")
+	  // Convert any remaining newlines to <br> tags, these will only be newlines in actual text content at this point
+      .replace(/\n/g, "<br>")
       // Remove Word-specific classes
       .replace(/\sclass=["']?MsoNormal["']?/gi, "");
   } else if (isPartialHtml && !isContentHtml) {
@@ -769,7 +813,7 @@ function cleanHtml(html, isPartialHtml) {
 
   // Step 9: Repair orphan table rows (Word paste)
   if (/<tr[\s>]/i.test(out) && !/<table[\s>]/i.test(out)) {
-    out = "<table><tbody>" + out + "</tbody></table>";
+    out = "<table>" + out + "</table>";
   }
   
   return out;

--- a/cp/richTextFieldWithTables/v1/index.js
+++ b/cp/richTextFieldWithTables/v1/index.js
@@ -57,7 +57,11 @@ summernote.on("summernote.paste", function (we, e) {
     return;
   }
   handleImagePasteFromFile(e);
-  summernote.summernote("pasteHTML", cleanHtml(clipboardHtml, true));
+  var cleanedHtml = cleanHtml(clipboardHtml, true);
+  cleanedHtml = stripSummernoteDefaults(cleanedHtml);
+  /* Wrap HTML around <span> tags to ensure it is pasted as a single node */
+  cleanedHtml = "<span>" + cleanedHtml + "</span>";
+  summernote.summernote("pasteHTML", cleanedHtml);
 });
 
 // After investigating, we determined that only these tags & attributes are necessary/supported in order to render all supported styles of the editor
@@ -751,7 +755,7 @@ function cleanHtml(html, isPartialHtml) {
   out = out.replace(/<a.*?href="(.*?)">(.*?)<\/a>/g, function ($0, $1, $2) {
     // Test this Regex here: https://regexr.com/6blub
     return $1.match(
-      /^(?:[A-Za-z0-9+\-.]+:)?(?:https:\/\/|file:\/\/|mailto:).*$/g
+      /^(?:[A-Za-z0-9+\-.]+:)?(?:https:\/\/|file:(?:\/\/|\\\\)|mailto:).*$/g
     )
       ? $0
       : $2;
@@ -768,6 +772,58 @@ function cleanHtml(html, isPartialHtml) {
     out = "<table><tbody>" + out + "</tbody></table>";
   }
   
+  return out;
+}
+
+/**
+ * Cleans an HTML string by removing default styles injected by Summernote and
+ * stripping out empty or redundant tags.
+ * @param {string} html - The HTML string to clean.
+ * @return {string} The cleaned HTML string.
+ */
+function stripSummernoteDefaults(html) {
+  if (!html) {
+    return "";
+  }
+  
+  var out = html;
+
+  // 1. Clean all style attributes
+  out = out.replace(/style="([^"]*)"/g, function(match, styleContent) {
+    var cleaned = styleContent
+      .replace(/background-color:\s*rgb\(\s*255\s*,\s*255\s*,\s*255\s*\)\s*;?\s*/gi, '')
+      .replace(/font-size:\s*14px\s*;?\s*/gi, '')
+      .replace(/text-align:\s*start\s*;?\s*/gi, '')
+      .replace(/float:\s*none\s*;?\s*/gi, '')
+      .replace(/;\s*;+/g, ';')
+      .replace(/^\s*;+\s*/, '')
+      .replace(/\s*;+\s*$/, '')
+      .trim();
+    
+    return cleaned ? 'style="' + cleaned + '"' : '';
+  });
+
+  // 2. Remove empty style attributes
+  out = out.replace(/\s*style=""\s*/g, '');
+
+  // 3. Clean up whitespace issues
+  out = out.replace(/\s+>/g, '>');
+  out = out.replace(/\s{2,}/g, ' ');
+
+  // 4. Remove empty spans and unwrap attribute-less spans
+  for (var i = 0; i < 10; i++) {
+    var before = out;
+    
+	out = out.replace(/<span[^>]*>\s*<\/span>/g, '');
+	out = out.replace(/<span\s*>([^]*?)<\/span>/g, '$1');
+    
+    // Break if nothing changed
+    if (before === out) break;
+  }
+
+  // Final cleanup
+  out = out.replace(/\s+>/g, '>');
+
   return out;
 }
 


### PR DESCRIPTION
1. Copy and Pasting text into Summernote RTE adds additional styling that Summernote injects by default. Addressed by implementing stripSummernoteDefaults().
Issue:
![RTE_ISSUE_2](https://github.com/user-attachments/assets/564b41cc-d023-4861-b772-e0214730388b)
Fix:
![RTE_FIX_2](https://github.com/user-attachments/assets/966a693c-e1e6-4777-a30e-e97daa286386)

2. Copy and Pasting text a few times caused the text to fall out of order. Addressed by restructuring the way order of how HTML is sanitized in the cleanHtml()
Issue:
![RTE_ISSUE_1](https://github.com/user-attachments/assets/364e7cf6-3c53-4251-8ab8-1f1b87e43be1)
Fix:
![RTE_FIX_1](https://github.com/user-attachments/assets/87bc3d16-2436-49db-b1d4-1bfad53e10af)

3. Copy and Pasting tables creates orphan tables. Addressed in cleanHTML() but identifying orphaned rows and wrapping them in table tags
Issue:
![RTE_ISSUE_3](https://github.com/user-attachments/assets/81bba371-6fa0-4ce9-894e-28562beec201)
Fix:
![RTE_FIX_3](https://github.com/user-attachments/assets/0e4d73dc-99a0-4356-ba6e-313609471717)

4. Copy and pasting multi-line text created spacing issues and impacts cursor placement. Addressed by switching from "pasteHTML" to "insertNode"
Issue:
![RTE_ISSUE_4](https://github.com/user-attachments/assets/0991b096-1178-43cd-87d5-dca25ddf1298)
Fix:
![RTE_FIX_4](https://github.com/user-attachments/assets/8ceb1bec-83bf-44ae-9570-561b8df2a532)

Overrall Enhancements: 
- Allow copy and pasting of text and images from RTE to RTE - does not auto reject any HTML that includes <img> tags.
- Support copy and pasting of multiple tables from Word or other RTEs.
- Update File Protocol to allow file:\\ as users tend to copy locally mapped network drives.

