### PR TITLE
a11y: replace role=img with visually-hidden text markers for diff blocks

### DIFF
--- a/cp/appian-component-plugin.xml
+++ b/cp/appian-component-plugin.xml
@@ -4,7 +4,7 @@
     <description>A simple rich text editor</description>
     <support supported="false" email="richtext-componentpluginsupport@appian.com" />
     <vendor name="Appian" url="https://www.appian.com"/>
-    <version>1.20.0</version>
+    <version>1.20.1</version>
   </plugin-info>
   <component rule-name="richTextField" version="1.0.0">
     <sdk-version>2.0.0</sdk-version>

--- a/cp/richTextFieldWithTables/v1/custom.css
+++ b/cp/richTextFieldWithTables/v1/custom.css
@@ -194,3 +194,18 @@ ins {
 del {
   text-decoration: none;
 }
+
+/* Visually-hidden text for screen reader accessibility announcements.
+   Used to announce boundaries of added/removed diff blocks.
+   Content is invisible but remains in the accessibility tree. */
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}

--- a/cp/richTextFieldWithTables/v1/i18n.js
+++ b/cp/richTextFieldWithTables/v1/i18n.js
@@ -13,8 +13,10 @@ const english_translations = {
   validationConnectedSystemResponse: "Response from connected system:",
   validationDocURLFailure: "Unable to obtain the doc URL from the connected system",
   default: "Default",
-  added: "Added: ",
-  removed: "Removed: ",
+  beginAdded: "Begin added text",
+  endAdded: "End added text",
+  beginRemoved: "Begin removed text",
+  endRemoved: "End removed text",
 };
 const french_translations = {
   textHeaderLarge: "Grand en-tête",
@@ -27,6 +29,8 @@ const french_translations = {
   validationConnectedSystemResponse: "Réponse du système connecté :",
   validationDocURLFailure: "Impossible d'obtenir l'URL du document à partir du système connecté",
   default: "Réglage par défaut",
-  added: "Ajouté : ",
-  removed: "Supprimé : ",
+  beginAdded: "Début du texte ajouté",
+  endAdded: "Fin du texte ajouté",
+  beginRemoved: "Début du texte supprimé",
+  endRemoved: "Fin du texte supprimé",
 };

--- a/cp/richTextFieldWithTables/v1/index.js
+++ b/cp/richTextFieldWithTables/v1/index.js
@@ -526,46 +526,109 @@ function isTextPresent(text) {
 }
 
 /**
- * Post-processes the readOnly DOM to replace <ins> and <del> elements with
- * aria-labeled <span> elements. This prevents VoiceOver from double-reading
- * the content while still announcing "added:" or "removed:" for screen readers.
+ * Post-processes the readOnly DOM to make diff markup (ins/del) accessible.
+ *
+ * Uses visually-hidden text markers at the boundaries of added/removed blocks
+ * so screen readers announce "Begin added text" / "End added text". This is
+ * the only method with full support across all screen reader + browser
+ * combinations (NVDA, JAWS, VoiceOver).
+ *
+ * Consecutive same-type blocks (not separated by unchanged or opposite-type
+ * content) get a single begin/end pair around the entire run.
+ *
+ * Replaces <ins>/<del> with plain <span> to prevent VoiceOver double-reading
+ * while avoiding invalid ARIA (role="img" on text content).
+ *
  * Only affects the rendered DOM — the stored richText value is never modified.
  */
 function makeInsDelAccessible() {
   var container = document.getElementById("summernote");
   if (!container) return;
 
-  container.querySelectorAll("ins").forEach(function (el) {
-    var span = document.createElement("span");
-    span.setAttribute("role", "img");
-    span.setAttribute("aria-label", getTranslation("added") + escapeAttr(el.textContent));
-    if (el.getAttribute("style")) {
-      span.setAttribute("style", el.getAttribute("style"));
-    }
-    span.innerHTML = el.innerHTML;
-    el.replaceWith(span);
-  });
+  processAccessibleBlocks(container, "ins", "added");
+  processAccessibleBlocks(container, "del", "removed");
+}
 
-  container.querySelectorAll("del").forEach(function (el) {
-    var span = document.createElement("span");
-    span.setAttribute("role", "img");
-    span.setAttribute("aria-label", getTranslation("removed") + escapeAttr(el.textContent));
-    if (el.getAttribute("style")) {
-      span.setAttribute("style", el.getAttribute("style"));
+/**
+ * Finds all elements of the given tag name, groups consecutive ones,
+ * wraps each group with visually-hidden begin/end markers, and replaces
+ * the original elements with plain <span>s (no ARIA attributes).
+ */
+function processAccessibleBlocks(container, tagName, type) {
+  var elements = Array.from(container.querySelectorAll(tagName));
+  if (elements.length === 0) return;
+
+  // Group consecutive same-type elements together
+  var groups = [];
+  var currentGroup = [elements[0]];
+
+  for (var i = 1; i < elements.length; i++) {
+    if (areConsecutive(elements[i - 1], elements[i])) {
+      currentGroup.push(elements[i]);
+    } else {
+      groups.push(currentGroup);
+      currentGroup = [elements[i]];
     }
-    span.innerHTML = el.innerHTML;
-    el.replaceWith(span);
+  }
+  groups.push(currentGroup);
+
+  // Process each group: add markers and replace elements
+  groups.forEach(function (group) {
+    var first = group[0];
+    var last = group[group.length - 1];
+
+    // Insert "Begin <type> text" before the first element
+    var beginKey = type === "added" ? "beginAdded" : "beginRemoved";
+    var beginMarker = createVisuallyHiddenSpan(getTranslation(beginKey));
+    first.parentNode.insertBefore(beginMarker, first);
+
+    // Insert "End <type> text" after the last element
+    var endKey = type === "added" ? "endAdded" : "endRemoved";
+    var endMarker = createVisuallyHiddenSpan(getTranslation(endKey));
+    if (last.nextSibling) {
+      last.parentNode.insertBefore(endMarker, last.nextSibling);
+    } else {
+      last.parentNode.appendChild(endMarker);
+    }
+
+    // Replace each <ins>/<del> with a plain <span> preserving style and content
+    group.forEach(function (el) {
+      var span = document.createElement("span");
+      if (el.getAttribute("style")) {
+        span.setAttribute("style", el.getAttribute("style"));
+      }
+      span.innerHTML = el.innerHTML;
+      el.replaceWith(span);
+    });
   });
 }
 
 /**
- * Escapes double quotes in a string for safe use in HTML attribute values.
- * @param {string} str - The string to escape
- * @return {string} The escaped string
+ * Two elements are consecutive if only whitespace or empty nodes separate them.
+ * If meaningful text or another element type sits between them, they are separate groups.
  */
-function escapeAttr(str) {
-  if (!str) return "";
-  return str.replace(/"/g, "&quot;");
+function areConsecutive(prev, curr) {
+  var node = prev.nextSibling;
+  while (node && node !== curr) {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      return false;
+    }
+    if (node.nodeType === Node.TEXT_NODE && node.textContent.trim() !== "") {
+      return false;
+    }
+    node = node.nextSibling;
+  }
+  return node === curr;
+}
+
+/**
+ * Creates a <span> with visually-hidden text for screen reader announcements.
+ */
+function createVisuallyHiddenSpan(text) {
+  var span = document.createElement("span");
+  span.className = "visually-hidden";
+  span.textContent = text;
+  return span;
 }
 
 /**
@@ -577,8 +640,8 @@ function setEditorContents() {
     // Then immediately destroy since setting the contents creates it
     summernote.summernote("code", cleanHtml(window.allParameters.richText));
     summernote.summernote("destroy");
-    // Post-process for accessibility: replace <ins>/<del> with aria-labeled spans
-    // to prevent VoiceOver double-reading while maintaining screen reader announcements
+    // Post-process for accessibility: inject visually-hidden markers around diff blocks
+    // and replace <ins>/<del> with plain <span>s to prevent VoiceOver double-reading
     makeInsDelAccessible();
   } else {
     // Otherwise, only update the contents if they've actually changed to avoid triggering the onChange event

--- a/cp/tests/helpers/loadRichTextFieldWithTables.js
+++ b/cp/tests/helpers/loadRichTextFieldWithTables.js
@@ -78,8 +78,10 @@ function setupGlobals() {
     validationConnectedSystemResponse: "Response from connected system:",
     validationDocURLFailure: "Unable to obtain the doc URL from the connected system",
     default: "Default",
-    added: "Added: ",
-    removed: "Removed: ",
+    beginAdded: "Begin added text",
+    endAdded: "End added text",
+    beginRemoved: "Begin removed text",
+    endRemoved: "End removed text",
   };
   global.french_translations = {
     textHeaderLarge: "Grand en-tête",
@@ -92,8 +94,10 @@ function setupGlobals() {
     validationConnectedSystemResponse: "Réponse du système connecté :",
     validationDocURLFailure: "Impossible d'obtenir l'URL du document à partir du système connecté",
     default: "Réglage par défaut",
-    added: "Ajouté : ",
-    removed: "Supprimé : ",
+    beginAdded: "Début du texte ajouté",
+    endAdded: "Fin du texte ajouté",
+    beginRemoved: "Début du texte supprimé",
+    endRemoved: "Fin du texte supprimé",
   };
   global.Appian = {
     getLocale: jest.fn(() => "en-US"),

--- a/cp/tests/helpers/setupGlobals.js
+++ b/cp/tests/helpers/setupGlobals.js
@@ -121,8 +121,10 @@ global.english_translations = {
   validationConnectedSystemResponse: "Response from connected system:",
   validationDocURLFailure: "Unable to obtain the doc URL from the connected system",
   default: "Default",
-  added: "Added: ",
-  removed: "Removed: ",
+  beginAdded: "Begin added text",
+  endAdded: "End added text",
+  beginRemoved: "Begin removed text",
+  endRemoved: "End removed text",
 };
 
 global.french_translations = {
@@ -159,8 +161,10 @@ global.french_translations = {
   validationConnectedSystemResponse: "Réponse du système connecté :",
   validationDocURLFailure: "Impossible d'obtenir l'URL du document à partir du système connecté",
   default: "Réglage par défaut",
-  added: "Ajouté : ",
-  removed: "Supprimé : ",
+  beginAdded: "Début du texte ajouté",
+  endAdded: "Fin du texte ajouté",
+  beginRemoved: "Début du texte supprimé",
+  endRemoved: "Fin du texte supprimé",
 };
 
 // ── Appian SDK mock ──────────────────────────────────────────────────

--- a/cp/tests/richTextFieldWithTables/makeInsDelAccessible.test.js
+++ b/cp/tests/richTextFieldWithTables/makeInsDelAccessible.test.js
@@ -1,34 +1,14 @@
 /**
- * Tests for makeInsDelAccessible() and escapeAttr() from richTextFieldWithTables/v1/index.js
+ * Tests for makeInsDelAccessible() from richTextFieldWithTables/v1/index.js
  *
- * makeInsDelAccessible replaces <ins> and <del> elements in the readOnly DOM
- * with aria-labeled <span> elements so screen readers announce "Added:" or
- * "Removed:" without VoiceOver double-reading the content.
+ * makeInsDelAccessible injects visually-hidden text markers at the boundaries
+ * of added/removed blocks and replaces <ins>/<del> with plain <span>s.
+ * This is the only method with full screen reader support across NVDA, JAWS, and VoiceOver.
  */
 
-const { makeInsDelAccessible, escapeAttr } = require("../../richTextFieldWithTables/v1/index.js");
+const { makeInsDelAccessible } = require("../../richTextFieldWithTables/v1/index.js");
 
-describe("escapeAttr", () => {
-  test("escapes double quotes", () => {
-    expect(escapeAttr('say "hello"')).toBe("say &quot;hello&quot;");
-  });
-
-  test("returns empty string for null/undefined", () => {
-    expect(escapeAttr(null)).toBe("");
-    expect(escapeAttr(undefined)).toBe("");
-    expect(escapeAttr("")).toBe("");
-  });
-
-  test("leaves strings without quotes unchanged", () => {
-    expect(escapeAttr("plain text")).toBe("plain text");
-  });
-
-  test("escapes multiple double quotes", () => {
-    expect(escapeAttr('"a" and "b"')).toBe("&quot;a&quot; and &quot;b&quot;");
-  });
-});
-
-describe("makeInsDelAccessible", () => {
+describe("makeInsDelAccessible - visually-hidden markers", () => {
   let container;
 
   beforeEach(() => {
@@ -36,124 +16,104 @@ describe("makeInsDelAccessible", () => {
     container.innerHTML = "";
   });
 
-  test("replaces <ins> with accessible span", () => {
-    container.innerHTML = "<ins>inserted text</ins>";
+  test("replaces <ins> with visually-hidden markers and plain span", () => {
+    container.innerHTML = '<p>before <ins><font color="#117C00">added word</font></ins> after</p>';
     makeInsDelAccessible();
 
-    const spans = container.querySelectorAll("span");
-    expect(spans).toHaveLength(1);
-    expect(spans[0].getAttribute("role")).toBe("img");
-    expect(spans[0].getAttribute("aria-label")).toBe("Added: inserted text");
-    expect(spans[0].innerHTML).toBe("inserted text");
+    // No role="img" or aria-label should exist
+    expect(container.querySelector('[role="img"]')).toBeNull();
+    expect(container.querySelector("[aria-label]")).toBeNull();
+
+    // Should have visually-hidden markers
+    var hiddenSpans = container.querySelectorAll(".visually-hidden");
+    expect(hiddenSpans.length).toBe(2);
+    expect(hiddenSpans[0].textContent).toBe("Begin added text");
+    expect(hiddenSpans[1].textContent).toBe("End added text");
+
+    // The <ins> should be replaced with a plain <span>
+    expect(container.querySelector("ins")).toBeNull();
   });
 
-  test("replaces <del> with accessible span", () => {
-    container.innerHTML = "<del>deleted text</del>";
-    makeInsDelAccessible();
-
-    const spans = container.querySelectorAll("span");
-    expect(spans).toHaveLength(1);
-    expect(spans[0].getAttribute("role")).toBe("img");
-    expect(spans[0].getAttribute("aria-label")).toBe("Removed: deleted text");
-    expect(spans[0].innerHTML).toBe("deleted text");
-  });
-
-  test("preserves style attribute from <ins>", () => {
-    container.innerHTML = '<ins style="color: red;">styled insert</ins>';
-    makeInsDelAccessible();
-
-    const span = container.querySelector("span");
-    expect(span.getAttribute("style")).toBe("color: red;");
-  });
-
-  test("preserves style attribute from <del>", () => {
-    container.innerHTML = '<del style="text-decoration: line-through;">styled delete</del>';
-    makeInsDelAccessible();
-
-    const span = container.querySelector("span");
-    expect(span.getAttribute("style")).toBe("text-decoration: line-through;");
-  });
-
-  test("does not add style attribute when element has none", () => {
-    container.innerHTML = "<ins>no style</ins>";
-    makeInsDelAccessible();
-
-    const span = container.querySelector("span");
-    expect(span.hasAttribute("style")).toBe(false);
-  });
-
-  test("handles multiple <ins> and <del> elements", () => {
+  test("replaces <del> with visually-hidden markers and plain span", () => {
     container.innerHTML =
-      "<p><ins>added A</ins> normal <del>removed B</del> more <ins>added C</ins></p>";
+      '<p>before <del><font color="#9F0019"><strike>removed word</strike></font></del> after</p>';
     makeInsDelAccessible();
 
-    const spans = container.querySelectorAll("span[role='img']");
-    expect(spans).toHaveLength(3);
-    expect(spans[0].getAttribute("aria-label")).toBe("Added: added A");
-    expect(spans[1].getAttribute("aria-label")).toBe("Removed: removed B");
-    expect(spans[2].getAttribute("aria-label")).toBe("Added: added C");
+    expect(container.querySelector('[role="img"]')).toBeNull();
+    expect(container.querySelector("[aria-label]")).toBeNull();
+
+    var hiddenSpans = container.querySelectorAll(".visually-hidden");
+    expect(hiddenSpans.length).toBe(2);
+    expect(hiddenSpans[0].textContent).toBe("Begin removed text");
+    expect(hiddenSpans[1].textContent).toBe("End removed text");
+
+    expect(container.querySelector("del")).toBeNull();
   });
 
-  test("preserves inner HTML (nested elements) within <ins>", () => {
-    container.innerHTML = "<ins><b>bold</b> and <i>italic</i></ins>";
+  test("consecutive same-type elements get single begin/end pair", () => {
+    container.innerHTML =
+      "<p><del><strike>word1</strike></del><del><strike>word2</strike></del>" +
+      "<del><strike>word3</strike></del></p>";
     makeInsDelAccessible();
 
-    const span = container.querySelector("span");
-    expect(span.innerHTML).toBe("<b>bold</b> and <i>italic</i>");
-    // aria-label uses textContent, so it flattens the nested HTML
-    expect(span.getAttribute("aria-label")).toBe("Added: bold and italic");
+    var hiddenSpans = container.querySelectorAll(".visually-hidden");
+    // One begin + one end for the entire run
+    expect(hiddenSpans.length).toBe(2);
+    expect(hiddenSpans[0].textContent).toBe("Begin removed text");
+    expect(hiddenSpans[1].textContent).toBe("End removed text");
   });
 
-  test("preserves inner HTML (nested elements) within <del>", () => {
-    container.innerHTML = "<del><b>bold</b> removed</del>";
+  test("non-consecutive blocks get separate markers", () => {
+    container.innerHTML = "<p><ins>added1</ins> unchanged text <ins>added2</ins></p>";
     makeInsDelAccessible();
 
-    const span = container.querySelector("span");
-    expect(span.innerHTML).toBe("<b>bold</b> removed");
-    expect(span.getAttribute("aria-label")).toBe("Removed: bold removed");
+    var hiddenSpans = container.querySelectorAll(".visually-hidden");
+    // Two separate groups = 2 begin + 2 end = 4 markers
+    expect(hiddenSpans.length).toBe(4);
+    expect(hiddenSpans[0].textContent).toBe("Begin added text");
+    expect(hiddenSpans[1].textContent).toBe("End added text");
+    expect(hiddenSpans[2].textContent).toBe("Begin added text");
+    expect(hiddenSpans[3].textContent).toBe("End added text");
   });
 
-  test("escapes double quotes in aria-label", () => {
-    container.innerHTML = '<ins>say "hello"</ins>';
+  test("mixed ins and del get independent markers", () => {
+    container.innerHTML = "<p><del>removed</del><ins>added</ins></p>";
     makeInsDelAccessible();
 
-    const span = container.querySelector("span");
-    expect(span.getAttribute("aria-label")).toBe("Added: say &quot;hello&quot;");
+    var hiddenSpans = container.querySelectorAll(".visually-hidden");
+    expect(hiddenSpans.length).toBe(4);
+    expect(hiddenSpans[0].textContent).toBe("Begin removed text");
+    expect(hiddenSpans[1].textContent).toBe("End removed text");
+    expect(hiddenSpans[2].textContent).toBe("Begin added text");
+    expect(hiddenSpans[3].textContent).toBe("End added text");
   });
 
-  test("no-ops when #summernote container does not exist", () => {
+  test("preserves inline styles on replacement spans", () => {
+    container.innerHTML = '<p><ins style="color: green;">styled</ins></p>';
+    makeInsDelAccessible();
+
+    var spans = container.querySelectorAll("p > span:not(.visually-hidden)");
+    var styledSpan = Array.from(spans).find(function (s) {
+      return s.getAttribute("style");
+    });
+    expect(styledSpan).not.toBeNull();
+    expect(styledSpan.getAttribute("style")).toBe("color: green;");
+  });
+
+  test("does not crash when no ins/del elements exist", () => {
+    container.innerHTML = "<p>plain text with no diff markers</p>";
+    expect(() => makeInsDelAccessible()).not.toThrow();
+    expect(container.querySelectorAll(".visually-hidden").length).toBe(0);
+  });
+
+  test("does not crash when summernote container is missing", () => {
     container.remove();
     expect(() => makeInsDelAccessible()).not.toThrow();
 
     // Restore for other tests
-    const div = document.createElement("div");
+    var div = document.createElement("div");
     div.id = "summernote";
     document.body.appendChild(div);
-  });
-
-  test("no-ops when container has no <ins> or <del>", () => {
-    container.innerHTML = "<p>just a paragraph</p>";
-    makeInsDelAccessible();
-
-    expect(container.innerHTML).toBe("<p>just a paragraph</p>");
-  });
-
-  test("handles empty <ins> element", () => {
-    container.innerHTML = "<ins></ins>";
-    makeInsDelAccessible();
-
-    const span = container.querySelector("span");
-    expect(span.getAttribute("aria-label")).toBe("Added: ");
-    expect(span.innerHTML).toBe("");
-  });
-
-  test("handles empty <del> element", () => {
-    container.innerHTML = "<del></del>";
-    makeInsDelAccessible();
-
-    const span = container.querySelector("span");
-    expect(span.getAttribute("aria-label")).toBe("Removed: ");
-    expect(span.innerHTML).toBe("");
   });
 
   test("removes all <ins> and <del> elements from the DOM", () => {
@@ -162,5 +122,24 @@ describe("makeInsDelAccessible", () => {
 
     expect(container.querySelectorAll("ins")).toHaveLength(0);
     expect(container.querySelectorAll("del")).toHaveLength(0);
+  });
+
+  test("handles empty <ins> element", () => {
+    container.innerHTML = "<ins></ins>";
+    makeInsDelAccessible();
+
+    var hiddenSpans = container.querySelectorAll(".visually-hidden");
+    expect(hiddenSpans.length).toBe(2);
+    expect(hiddenSpans[0].textContent).toBe("Begin added text");
+    expect(hiddenSpans[1].textContent).toBe("End added text");
+  });
+
+  test("preserves inner HTML (nested elements) within replaced spans", () => {
+    container.innerHTML = "<ins><b>bold</b> and <i>italic</i></ins>";
+    makeInsDelAccessible();
+
+    var spans = container.querySelectorAll("span:not(.visually-hidden)");
+    expect(spans.length).toBe(1);
+    expect(spans[0].innerHTML).toBe("<b>bold</b> and <i>italic</i>");
   });
 });


### PR DESCRIPTION
Remove invalid ARIA (role=img + aria-label) from ins/del accessibility handling. Replace with visually-hidden text markers that announce 'Begin added/removed text' and 'End added/removed text' boundaries.

This is the only method with full screen reader support across NVDA, JAWS, and VoiceOver. Consecutive same-type blocks get a single begin/end pair to avoid verbose announcements.

- Replace makeInsDelAccessible() with visually-hidden approach
- Remove escapeAttr() (no longer needed)
- Add .visually-hidden CSS class
- Add i18n keys for marker text (English + French)
- Update tests to verify new behavior
- Bump version to 1.20.1